### PR TITLE
Fix network connection settings bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ VM options:
     -t, --template TEMPLATE          VM template: small, medium, large, xlarge
         --custom cpu,mem,sda         CPU, Memory, and /dev/sda
         --sdb [10G{,/pub}]           Add /dev/sdb. Size and mount point optional.
-        --vlan VLAN                  VLAN
+        --vlan VLAN                  VLAN (This option is deprecated, but code left in place commented out if you need it)
         --[no-]iso                   Build ISO (true)
         --[no-]upload                Upload the ISO to the ESX cluster (true)
         --[no-]vm                    Build the VM (true)
@@ -89,7 +89,7 @@ Most of the arguments should be self-explanatory, but a few merit discussion.
 
 * **--datastore**: this is a regular expression that `mkvm.rb` will use to find the datastore to use when building the VM. `mkvm.rb` will use this regex to enumerate all the matching datastores and then select the one with the most space free. This should help ensure that `mkvm.rb` doesn't over-populate any single datastore (unless, of course, you only have a single datastore!).  This also allows you to control, on the fly, which datastore to use.
 * **--isostore**: this is the datastore to which the resultant ISO file will be pushed. This store should be accessible by all the hosts within the cluster, to ensure that any host can build the VM.  A low-performance NFS share is usually suitable for this purpose.
-* **--vlan**: this is the full name of the VLAN to which the VM will be assigned. You may need to wrap this option in quotes.
+* **--vlan**: this is the full name of the VLAN to which the VM will be assigned. This option is commented out as vlan does not apply to DV Switching.  If you don't use DV Switching then you may want to uncomment this code.
 * **--gateway**: this is the default route to use for this VM.  It will be used for the Kickstart process, as well as for the resultant VM once built.  If not specified, it defaults to the .1 address in the same network as the IP of the VM.  Thus, if the VM IP is 192.168.1.5 and no gateway is specified, `mkvm.rb` will use 192.168.1.1.
 * **--sdb [size{,path}]**: with no additional arguments, `sdb` adds a 10G /dev/sdb disk to the VM.  Additionally, the value `SDB` is added to the Kickstart boot line.  You may specify a size for your /dev/sdb disk.  You may also specify a mount point for this disk.  If you do so, the resultant Kickstart boot line will look like `SDB=/your/path`.  Note that `mkvm.rb` **does not** actually mount this for you.  It is your responsibility to handle this in your Kickstart file.
 * **--app-env**: this is a value that gets added to the Kickstart command line. Your Kickstart process can parse this option and act accordingly. We use this to define a custom Puppet fact for whether the server is production, testing, development, etc.
@@ -118,15 +118,18 @@ If a file `.mkvm.yaml` exists in the user's home directory, it will be loaded an
 :dns: 192.168.1.2,192.168.1.3
 :domain: example.com
 :app_env: development
-:vlan: Production
 :srcdir: /nfs/isolinux
 :outdir: /nfs/isos
 :dvswitch:
   'dc1': 'dvswitch1uuid'
   'dc2': 'dvswitch2uuid'
 :portgroup':
-  '192.168.20.0': 'dvportgroup1-number'
-  '192.168.30.0': 'dvportgroup2-number'
+  '192.168.20.0':
+    name: 'Production'
+    portgroup: 'dvportgroup1-number'
+  '192.168.30.0':
+    name: 'DMZ'
+    portgroup: 'dvportgroup2-number'
 ```
 
 See `mkvm.yaml.sample` for a full example.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ General options:
     -v, --debug                      Verbose output
     -h, --help                       Display this screen
 ```
-The only mandatory arguments are `-t` (or `--custom`) and a hostname. 
+The only mandatory arguments are `-t` (or `--custom`) and a hostname with no plugins installed.  The plugins provided in this repo will enforce additional mandatory arguments. 
 
 If no `-i` flag is supplied, `mkvm.rb` will, by default, perform a DNS lookup for the supplied hostname and use the results.  If no `-i` flag is supplied and the DNS lookup fails, `mkvm.rb` will fail.
 
@@ -103,7 +103,7 @@ Arguments that accept sizes can pass human-friendly suffixes:
 * T = Tebibytes
 
 ## User Defaults
-If a file `.mkvm.yaml` exists in the user's home directory, it will be loaded and the values found therein will be used for defaults. These defauls can still be overridden by command-line switches.
+If a file `.mkvm.yaml` exists in the user's home directory, it will be loaded and the values found therein will be used for defaults. These defauls can still be overridden by command-line switches. The `:dvswitch` and `:portgroup` structures must be defined here.
 
 ```yaml
 :host: vcenter.example.com
@@ -121,6 +121,12 @@ If a file `.mkvm.yaml` exists in the user's home directory, it will be loaded an
 :vlan: Production
 :srcdir: /nfs/isolinux
 :outdir: /nfs/isos
+:dvswitch:
+  'dc1': 'dvswitch1uuid'
+  'dc2': 'dvswitch2uuid'
+:portgroup':
+  '192.168.20.0': 'dvportgroup1-number'
+  '192.168.30.0': 'dvportgroup2-number'
 ```
 
 See `mkvm.yaml.sample` for a full example.

--- a/mkvm.yaml.sample
+++ b/mkvm.yaml.sample
@@ -11,8 +11,17 @@
 :url: https://ks.example.com/rhel6.ks
 :dir: /usr/local/isolinux
 :domain: example.com
-:vlan: Production
 :make_iso: true
 :upload_iso: true
 :make_vm: true
 :power_on: true
+:dvswitch:
+  'dc1': 'dvswitch1uuid'
+  'dc2': 'dvswitch2uuid'
+:network':
+  '192.168.20.0':
+    name: 'Prodcution'
+    portgroup: 'dvportgroup1-number'
+  '192.168.30.0':
+    name: 'DMZ'
+    portgroup: 'dvportgroup2-number'

--- a/plugins/autoip.rb
+++ b/plugins/autoip.rb
@@ -19,8 +19,13 @@ class Autoip < Plugin
 
   def self.pre_validate options
     # if no subnet specified, use the APP_ENV
-    options[:subnet] = options[:app_env] if ! options[:subnet]
     if ! options[:ip]
+      if ! options[:subnet]
+        abort "Subnet (-s) is a required parameter.  This needs to be a dotted quad (ie. 10.1.4.0)" 
+      end
+      if ! options[:auto_uri]
+	abort "IPAM uri (--auto_uri) is required."
+      end
       # Remove any 'DOMAIN\' prefix from the username
       username = options[:username]
       username = username.gsub(/^.+\\(.*)/, '\1')

--- a/plugins/ip.rb
+++ b/plugins/ip.rb
@@ -53,7 +53,7 @@ class Ip < Plugin
 
   def self.post_validate options
     if ! options[:ip]
-      about "ERROR: No IP address specified!"
+      abort "ERROR: No IP address specified!"
     end
 
     if options[:ip] !~ Resolv::IPv4::Regex


### PR DESCRIPTION
The fix is simple, discovering the required data proved otherwise.  In
lieu of spending more hours attempting something with the VMWare API
that may not be possible I created 2 required data structures that map
known entities to their network-specific values.

If we go with this route every user of mkvm.rb will need to add this
structure to their ~/.mkvm.yaml.  The structure is presented in the
README.md file.  Specific values for CMM will be provided if we decide
to merge.