### PR TITLE
Make app_env an optional part of the kickstart

### DIFF
--- a/lib/kickstart.rb
+++ b/lib/kickstart.rb
@@ -60,8 +60,9 @@ class Kickstart < Mkvm
     end
 
     # finally, let's build up our KS line and add it to the options hash
-    ks_line="ks=#{options[:url]} noverifyssl ksdevice=#{options[:ksdevice]} ip=#{options[:ip]} netmask=#{options[:netmask]} gateway=#{options[:gateway]} hostname=#{options[:hostname]} #{nameserver_string} APP_ENV=#{options[:app_env]}"
-    # add the APP_ID, if one was supplied
+    ks_line="ks=#{options[:url]} noverifyssl ksdevice=#{options[:ksdevice]} ip=#{options[:ip]} netmask=#{options[:netmask]} gateway=#{options[:gateway]} hostname=#{options[:hostname]} #{nameserver_string}"
+    # add APP_ENV and APP_ID, if they were supplied
+    ks_line << " APP_ENV=#{options[:app_env]}" if options[:app_env]
     ks_line << " APP_ID=#{options[:app_id]}" if options[:app_id]
     ks_line << " SDB" if options[:sdb]
     ks_line << "=#{options[:sdb_path]}" if options[:sdb_path]


### PR DESCRIPTION
We have updated our build process to encapsulate the server app_env into
the hostname, and a custom fact parses the hostname to populate the
app_env fact.

This change removes the app_env value from the Kickstart boot line if
the `--app-env` option is not supplied.  This makes it possible to still
define an app_env if necessary.