### PR TITLE
Restrict ISO VOLUMEID to 32 chars max

### DIFF
--- a/lib/iso.rb
+++ b/lib/iso.rb
@@ -44,7 +44,7 @@ class ISO < Mkvm
     text = IO.read( "#{tmp_dir}/isolinux/isolinux.cfg" )
     text.gsub!(/KICKSTART_PARMS/, options[:ks_line])
     IO.write( "#{tmp_dir}/isolinux/isolinux.cfg", text )
-    system( "mkisofs -quiet -o #{outdir}/#{isoname} -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -J -R -V '#{hostname}' #{tmp_dir}" )
+    system( "mkisofs -quiet -o #{outdir}/#{isoname} -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -J -R -V '#{hostname[0..32]}' #{tmp_dir}" )
     # clean up after ourselves
     FileUtils.rm_rf "#{tmp_dir}"
     FileUtils.chmod_R 0755, "#{outdir}/#{isoname}"


### PR DESCRIPTION
In the event that you create a VM with an absurdly long hostname, the
mkisofs invocation may fail with
```
mkisofs: Volume ID string too long (cur. 38 max. 32 chars).
```
This ensures that the volume ID is restricted to at most 32 characters
by simply truncating the hostname.