### PR TITLE
dropped menu default in upgrade to 7.2

### DIFF
--- a/isolinux/7/isolinux.cfg
+++ b/isolinux/7/isolinux.cfg
@@ -60,6 +60,7 @@ menu separator # insert an empty line
 
 label linux
   menu label ^Install Red Hat Enterprise Linux 7.2
+  menu default
   kernel vmlinuz
   append initrd=initrd.img KICKSTART_PARMS
 


### PR DESCRIPTION
This causes builds to stop at the isolinux menu and not proceed.