### PR TITLE
Add support for extraConfig.

### DIFF
--- a/lib/kickstart.rb
+++ b/lib/kickstart.rb
@@ -36,9 +36,6 @@ class Kickstart < Mkvm
     opts.on( '--app-id APP_ID', 'APP_ID') do |x|
       options[:app_id] = x
     end
-    opts.on( '--extra "ONE=1 TWO=2"', 'extra args to pass to boot line') do |x|
-      options[:extra] = x
-    end
   end
 
   def validate(options)

--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 end

--- a/mkvm.rb
+++ b/mkvm.rb
@@ -59,6 +59,9 @@ vsphere.optparse(opts, options)
 plugins.each { |p| Kernel.const_get(p).optparse(opts, options) }
 # and some useful general options
 opts.separator 'General options:'
+opts.on( '--extra "ONE=1 TWO=2"', 'extra args to pass to boot line or to extraConfigs in the case of VM clone') do |x|
+  options[:extra] = x
+end
 opts.on('-v', '--debug', 'Enable verbose output') do |x|
   options[:debug] = true
 end


### PR DESCRIPTION
This change adds support for defining [extraConfig](https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.ConfigSpec.html) on the VM.  This allows us to define arbitrary key/value pairs on the VM so we can discover things like the mount point for the `sdb` drive or static puppet facts on the guest.

These pieces of data are defined as `guestinfo.key => value` on the VM and can be looked up using something like:
```
> vmtoolsd --cmd "info-get guestinfo.sdb_path"
/var/lib/test
> vmtoolsd --cmd "info-get guestinfo.0"
testkey=testvalue
> vmtoolsd --cmd "info-get guestinfo.1"
testkey2=testvalue2
```

For the `sdb_path` we know the name of the key explicitly, but in the case of custom static facts we don't know the key names so we chose to use a 0 based range.  This allows for the firstboot script to iterate over a sane range and discover key/value pairs that should be set as puppet static facts.