### PR TITLE
Adding puppet & satellite support to rmvm.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,34 +185,5 @@ Create an ISO for a medium RHEL 7 system named foobar and pass a couple of extra
 $ ./mkvm.rb -t medium -r 7 --extra "console=ttyS0 ks.sendmac noverifyssl sshd" foobar
 ```
 
-## Removing servers from Puppet with rmvm.rb
-To remove a server from Puppet, you will need a certificate/key pair that is signed by your Puppet CA and allowed access to the ```certificate status``` end point. Access to the ```certificate status``` end point is configured in your Puppet server's auth.conf:
-```
-authorization: {
-    ...
-    rules: [
-        ...
-        {
-            "allow" : [
-                "pe-internal-dashboard"
-            ],
-						"match-request" : {
-                "method" : [
-                    "get",
-                    "put",
-                    "delete"
-                ],
-                "path" : "/puppet-ca/v1/certificate_status",
-                "query-params" : {},
-                "type" : "path"
-            },
-            "name" : "puppetlabs certificate status",
-            "sort-order" : 500
-        }
-    ...
-```
-
-In the above example, only the ```pe-internal-dashboard``` cert is allowed to access the ```certificate status``` end-point. This is the default configuration for a Puppet Enterprise installation. You can either get the certificate/key files for pe-internal-dashboard or generate a new certificate/key pair, sign it with the Puppet CA, and add it to the "allow" list in auth.conf.
-
 ## License
 mkvm.rb is copyright 2014, CoverMyMeds, LLC and is released under the terms of the [GNU General Public License, version 2](http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt).

--- a/README.md
+++ b/README.md
@@ -185,5 +185,34 @@ Create an ISO for a medium RHEL 7 system named foobar and pass a couple of extra
 $ ./mkvm.rb -t medium -r 7 --extra "console=ttyS0 ks.sendmac noverifyssl sshd" foobar
 ```
 
+## Removing servers from Puppet with rmvm.rb
+To remove a server from Puppet, you will need a certificate/key pair that is signed by your Puppet CA and allowed access to the ```certificate status``` end point. Access to the ```certificate status``` end point is configured in your Puppet server's auth.conf:
+```
+authorization: {
+    ...
+    rules: [
+        ...
+        {
+            "allow" : [
+                "pe-internal-dashboard"
+            ],
+						"match-request" : {
+                "method" : [
+                    "get",
+                    "put",
+                    "delete"
+                ],
+                "path" : "/puppet-ca/v1/certificate_status",
+                "query-params" : {},
+                "type" : "path"
+            },
+            "name" : "puppetlabs certificate status",
+            "sort-order" : 500
+        }
+    ...
+```
+
+In the above example, only the ```pe-internal-dashboard``` cert is allowed to access the ```certificate status``` end-point. This is the default configuration for a Puppet Enterprise installation. You can either get the certificate/key files for pe-internal-dashboard or generate a new certificate/key pair, sign it with the Puppet CA, and add it to the "allow" list in auth.conf.
+
 ## License
 mkvm.rb is copyright 2014, CoverMyMeds, LLC and is released under the terms of the [GNU General Public License, version 2](http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt).

--- a/mkvm.yaml.sample
+++ b/mkvm.yaml.sample
@@ -15,6 +15,13 @@
 :upload_iso: true
 :make_vm: true
 :power_on: true
+:sat_url: https://satellite.example.com/rpc/api
+:sat_username: Admin
+:puppetmaster_url: https://puppetmaster.example.com
+:puppetdb_url: https://puppetdb.example.com
+:puppet_env: Production
+:puppet_cert: /path/to/cert.pem
+:puppet_key: /path/to/key.pem
 :add_uri: https://ipam.dev/api/getFreeIP.php?subnet=SUBNET&apiapp=APIAPP&apitoken=APITOKEN&host=HOSTNAME&user=USER
 :del_uri: https://ipam.dev/api/removeHost.php?host=HOSTNAME&apiapp=APIAPP&apitoken=APITOKEN
 :apiapp: ipamip
@@ -24,7 +31,7 @@
   'dc2': 'dvswitch2uuid'
 :network':
   '192.168.20.0':
-    name: 'Prodcution'
+    name: 'Production'
     portgroup: 'dvportgroup1-number'
   '192.168.30.0':
     name: 'DMZ'

--- a/rmvm.rb
+++ b/rmvm.rb
@@ -3,22 +3,29 @@
 # Author: Doug Morris <dmorris@covermymeds.com>/Scott Merrill <smerrill@covermymeds.com>
 # Released under the terms of the GPL version 2
 #   http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
-gem 'rbvmomi', '1.6.0'
 require "erb"
-require 'io/console'
+require "io/console"
 require "ipaddr"
 require "net/https"
-require "net/smtp"
-require 'optparse'
-require 'rbvmomi'
-require 'rubygems'
+require "xmlrpc/client"
+require "openssl"
 require "uri"
-require 'yaml'
+require "net/smtp"
+require "optparse"
+require "rbvmomi"
+require "rubygems"
+require "yaml"
+require "json"
+require "pry"
 
 # establish a couple of sane default values
 options = {
-  :username   => ENV['USER'],
+  :username   => ENV["USER"],
   :insecure   => true,
+  :satellite  => true,
+  :puppet     => true,
+  :puppet_env => "Production",
+  :ipam       => true,
 }
 
 # read config from mkvm.yaml, if it exists
@@ -44,49 +51,93 @@ _self = File.basename($0)
 # parse our command-line options
 optparse = OptionParser.new do|opts|
   opts.banner = "Usage: #{_self} [options] hostname"
-  opts.separator ''
-  opts.separator 'VSphere options:'
-  opts.on( '-u', '--user USER', "vSphere user name (#{options[:username]})") do |x|
+  opts.separator ""
+  opts.separator "VSphere options:"
+  opts.on( "-u", "--user USER", "vSphere user name (#{options[:username]})") do |x|
     options[:username] = x
   end
-  opts.on( '-p', '--password PASSWORD', 'vSphere password') do |x|
+  opts.on( "-p", "--password PASSWORD", "vSphere password") do |x|
     options[:password] = x
   end
-  opts.on( '-H', '--host HOSTNAME', "vSphere host (#{options[:host]})") do |x|
+  opts.on( "-H", "--host HOSTNAME", "vSphere host (#{options[:host]})") do |x|
     options[:host] = x
   end
-  opts.on( '-D', '--dc DATACENTER', "vSphere data center (#{options[:dc]})") do |x|
+  opts.on( "-D", "--dc DATACENTER", "vSphere data center (#{options[:dc]})") do |x|
     options[:dc] = x
   end
-  opts.on( '--[no-]insecure', "Do not validate vSphere SSL certificate (#{options[:insecure]})") do |x|
-    options[:insecure] = x
+  opts.separator ""
+
+  opts.separator "Satellite options:"
+  opts.on("--no-satellite", "Do not remove from Satellite") do |x|
+    options[:satellite] = false
   end
-  opts.separator 'Email options'
-  opts.on( '--smtp server', "SMTP server to use to send email (#{options[:mail_server]})") do |x|
-    options[:smtp_server] = x
+  opts.on("--sat-url URL", "Satellite server URL (#{options[:sat_url]})") do |x|
+    options[:sat_url] = x
   end
-  opts.on( '--from address', "Email address from which to send email (#{options[:mail_from]})") do |x|
-    options[:smtp_server] = x
+  opts.on("--sat-username USERNAME", "Satellite user name (#{options[:sat_username] or options[:username]})") do |x|
+    options[:sat_username] = x
   end
-  opts.on( '--to address', "Email address to which to send email (#{options[:mail_to]})") do |x|
-    options[:smtp_server] = x
+  opts.on("--sat-password PASSWORD", "Satellite password") do |x|
+    options[:sat_password] = x
   end
-  opts.separator 'IPAM options:'
-  opts.on( '--del-uri uri', "Delete URI for IPAM system (#{options[:del_uri]})") do |x|
+  opts.separator ""
+
+  opts.separator "Puppet options:"
+  opts.on("--no-puppet", "Do not remove from puppet") do |x|
+    options[:puppet] = false
+  end
+  opts.on("--puppetmaster-url URL", "Puppetmaster server URL (#{options[:puppetmaster_url]})") do |x|
+    options[:puppetmaster_url] = x
+  end
+  opts.on("--puppetdb-url URL", "PuppetDB server URL (#{options[:puppetdb_url] or options[:puppetmaster_url]})") do |x|
+    options[:puppetdb_url] = x
+  end
+  opts.on("--puppet-env ENV", "Server's Puppet environment (#{options[:puppet_env]})") do |x|
+    options[:puppet_env] = x
+  end
+  opts.on("--puppet-cert CERT", "Certificate signed by Puppet CA (#{options[:puppet_cert]})") do |x|
+    options[:puppet_cert] = x
+  end
+  opts.on("--puppet-key KEY", "Key for puppet-cert (#{options[:puppet_key]})") do |x|
+    options[:puppet_key] = x
+  end
+  opts.separator ""
+
+  opts.separator "IPAM options:"
+  opts.on("--no-ipam", "Do not remove from IPAM") do |x|
+    options[:ipam] = false
+  end
+  opts.on( "--del-uri URL", "Delete URI for IPAM system (#{options[:del_uri]})") do |x|
     options[:del_uri] = x
   end
-  opts.on( '--apiapp apiapp', "Name of api application to use (#{options[:apiapp]})") do |x|
+  opts.on( "--apiapp APIAPP", "Name of api application to use (#{options[:apiapp]})") do |x|
     options[:apiapp] = x
   end
-  opts.on( '--apitoken apitoken', "Token to use with the api application (#{options[:apitoken]})") do |x|
+  opts.on( "--apitoken APITOKEN", "Token to use with the api application (#{options[:apitoken]})") do |x|
     options[:apitoken] = x
   end
-  opts.separator ''
-  opts.separator 'General options:'
-  opts.on( '-v', '--debug', 'Verbose output') do
+  opts.separator ""
+
+  opts.separator "Email options"
+  opts.on( "--smtp SERVER", "SMTP server to use to send email (#{options[:mail_server]})") do |x|
+    options[:smtp_server] = x
+  end
+  opts.on( "--from ADDRESS", "Email address from which to send email (#{options[:mail_from]})") do |x|
+    options[:smtp_server] = x
+  end
+  opts.on( "--to ADDRESS", "Email address to which to send email (#{options[:mail_to]})") do |x|
+    options[:smtp_server] = x
+  end
+  opts.separator ""
+
+  opts.separator "General options:"
+  opts.on( "--[no-]insecure", "Do not validate SSL certificates (#{options[:insecure]})") do |x|
+    options[:insecure] = x
+  end
+  opts.on( "-v", "--debug", "Verbose output") do
     $debug = true
   end
-  opts.on( '-h', '--help', 'Display this screen' ) do
+  opts.on( "-h", "--help", "Display this screen" ) do
     puts opts
     exit
   end
@@ -110,9 +161,9 @@ options[:hostname] = ARGV[0].downcase
 
 # we don't want to require passords on the command line
 if not options[:password]
-  print 'Password: '
+  print "Password: "
   options[:password] = STDIN.noecho(&:gets).chomp
-  puts ''
+  puts ""
 end
 
 VIM = RbVmomi::VIM
@@ -120,14 +171,14 @@ VIM = RbVmomi::VIM
 vim = VIM.connect( { :user => options[:username], :password => options[:password], :host => options[:host], :insecure => options[:insecure] } ) or abort $!
 dc = vim.serviceInstance.find_datacenter(options[:dc]) or abort "vSphere data center #{options[:dc]} not found"
 
-debug( 'INFO', "Connected to datacenter #{options[:dc]}" )
+debug( "INFO", "Connected to datacenter #{options[:dc]}" )
 
 vm = dc.find_vm(options[:hostname]) or abort "Unable to locate #{options[:hostname]} in data center #{options[:dc]}"
 pwrs = vm.runtime.powerState
 
 # If the vm is powered on, power off and send email
 # If the vm is powered off, deletd the vm and remove from IPAM
-if pwrs == 'poweredOn'
+if pwrs == "poweredOn"
   puts "Powering off #{options[:hostname]}"
   vm.PowerOffVM_Task.wait_for_completion
 
@@ -148,24 +199,173 @@ END_MSG
     end
   end
 
-elsif pwrs == 'poweredOff'
+elsif pwrs == "poweredOff"
   puts "Destroying #{options[:hostname]}"
   vm.Destroy_Task.wait_for_completion
   puts "#{options[:hostname]} has been destroyed/removed from VMware."
 
-  puts "Removing #{options[:hostname]} from IPAM...."
+  if options[:satellite]
+    puts "Removing #{options[:hostname]} from Satellite...."
 
-  # Send delete request to phpipam system
-  uri = options[:del_uri].gsub(/APIAPP|APITOKEN|HOSTNAME/, {'APIAPP' => options[:apiapp], 'APITOKEN' => options[:apitoken], 'HOSTNAME' => options[:hostname],})
-  uri = URI.escape(uri)
-  uri = URI.parse(uri)
-  http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = true
-  request = Net::HTTP::Get.new(uri.request_uri)
-  response = http.request(request)
-  if response.code != "200"
-    abort "There was an error with your IPAM request: #{response.code}"
+    # If we weren't given different satellite credentials, use vSphere credentials
+    options[:sat_username] = options[:sat_username] ? options[:sat_username] : options[:username]
+    options[:sat_password] = options[:sat_password] ? options[:sat_password] : options[:password]
+
+    client = XMLRPC::Client.new2(options[:sat_url])
+
+    # Disable certificate verification
+    # TODO: Support for secure connections?
+    client.instance_variable_get("@http").verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    # Check to see if we have valid user credentials for Satellite
+    begin
+      key = client.call("auth.login", options[:sat_username], options[:sat_password])
+    rescue XMLRPC::FaultException
+      abort "Unable to authenticate to Satellite. Manual deletion required."
+    end
+
+    # Search Satellite for our system's hostname
+    response = client.call("system.search.hostname", key, options[:hostname])
+
+    # Ensure that exactly one response was returned form Satellite
+    system = response.pop
+    if not system or response.any?
+      abort "Unable to match '#{options[:hostname]}' in Satellite. Manual deletion required."
+    end
+
+    # Delete the system from Satellite
+    begin
+      client.call("system.deleteSystem", key, system["id"])
+      puts "Server '#{options[:hostname]}' deleted from Satellite."
+    rescue XMLRPC::FaultException
+      abort "Unable to delete server '#{options[:hostname]}' from Satellite. Manual deletion required."
+      # TODO: print the Satellite error
+    end
   end
-  del_response = response.body
-  puts "#{del_response}"
+
+  if options[:puppet]
+    puts "Removing #{options[:hostname]} from Puppet...."
+
+    # Defaults to build URLs
+    puppetmaster_default_port = 8140
+    puppetmaster_default_path = "/puppet-ca/v1/certificate_status/#{options[:hostname]}"
+    puppetdb_default_port = 8081
+    puppetdb_default_path = "/pdb/cmd/v1"
+
+    # If a puppetdb_url wasn't given, just use the puppetmaster_url since most installations are one-node
+    options[:puppetdb_url] = options[:puppetdb_url] ? options[:puppetdb_url] : options[:puppetmaster_url]
+
+    # Generate URI object for puppet URLs
+    puppetmaster_url = URI.parse(URI.escape(options[:puppetmaster_url]))
+    puppetdb_url = URI.parse(URI.escape(options[:puppetdb_url]))
+
+    # TODO: Clean this up
+    # Set default port if none were provided
+    puppetmaster_url.port = [80, 443].include?(puppetmaster_url.port) ? puppetmaster_default_port : puppetmaster_url.port
+    puppetdb_url.port = [80, 443].include?(puppetdb_url.port) ? puppetdb_default_port : puppetdb_url.port
+
+    # Set default path if none were provided
+    puppetmaster_url.path = puppetmaster_url.path.empty? ? puppetmaster_default_path : puppetmaster_url.path
+    puppetdb_url.path = puppetdb_url.path.empty? ? puppetdb_default_path : puppetdb_url.path
+
+    # Set our environment in the puppetmaster url query
+    puppetmaster_url.query = "environment=#{options[:puppet_env]}"
+
+    # Load Certificate & key objects
+    if options[:puppet_cert]
+      options[:puppet_cert] = OpenSSL::X509::Certificate.new File.read options[:puppet_cert]
+    end
+    if options[:puppet_key]
+      options[:puppet_key] = OpenSSL::PKey::RSA.new File.read options[:puppet_key]
+    end
+
+    #
+    # PUPPETDB DEACTIVATE REQUEST
+    #
+    # Setup http object
+    http = Net::HTTP.new(puppetdb_url.host, puppetdb_url.port)
+    http.use_ssl = true
+    http.ssl_version = :TLSv1
+    http.cert = options[:puppet_cert]
+    http.key = options[:puppet_key]
+
+    # Disable cerificate verification
+    # TODO: Support for secure connections?
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    # Build HTTP PUT request
+    request = Net::HTTP::Post.new(puppetdb_url.path, initheader = {
+      "Content-Type" => "application/json",
+      "Accept" => "application/json"
+    })
+    request.body = {
+      "command" => "deactivate node",
+      "version" => 3,
+      "payload" => {"certname" => options[:hostname]},
+    }.to_json
+
+    # Send request to API
+    response = http.start {|http| http.request(request)}
+    if not response.code.start_with? "2"
+      abort "There was an error with your PuppetDB request: #{response.code}"
+    end
+    puts "Server '#{options[:hostname]}' deactivated in PuppetDB. Request uuid: '#{JSON.parse(response.body)["uuid"]}'"
+
+    #
+    # PUPPET CERT REVOKE/DELETE REQUESTS
+    #
+    # TODO: possible to reuse previous Net::HTTP object?
+    # Setup http object
+    http = Net::HTTP.new(puppetmaster_url.host, puppetmaster_url.port)
+    http.use_ssl = true
+    http.ssl_version = :TLSv1
+    http.cert = options[:puppet_cert]
+    http.key = options[:puppet_key]
+
+    # Disable cerificate verification
+    # TODO: Support for secure connections?
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    # Build HTTP PUT & DELETE requests
+    requests = []
+
+    # PUT Request to revoke the cert
+    revoke_request = Net::HTTP::Put.new(puppetmaster_url.path, initheader = {"Content-Type" => "text/pson"})
+    revoke_request.body = {"desired_state" => "revoked"}.to_json
+    requests << revoke_request
+
+    # DELETE request to delete the cert
+    delete_request = Net::HTTP::Delete.new(puppetmaster_url.path, initheader = {"Accept" => "pson"})
+    requests << delete_request
+
+    http.start do |http|
+      requests.each do |request|
+        response = http.request request
+
+        if not response.code.start_with? "2"
+          abort "There was an error with your Puppet API request: #{response.code}"
+        end
+      end
+    end
+
+    puts "Puppet certificates for server '#{options[:hostname]}' revoked & removed"
+  end
+
+  if options[:ipam]
+    puts "Removing #{options[:hostname]} from IPAM...."
+
+    # Send delete request to phpipam system
+    uri = options[:del_uri].gsub(/APIAPP|APITOKEN|HOSTNAME/, {"APIAPP" => options[:apiapp], "APITOKEN" => options[:apitoken], "HOSTNAME" => options[:hostname],})
+    uri = URI.escape(uri)
+    uri = URI.parse(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    request = Net::HTTP::Get.new(uri.request_uri)
+    response = http.request(request)
+    if response.code != "200"
+      abort "There was an error with your IPAM request: #{response.code}"
+    end
+    del_response = response.body
+    puts "#{del_response}"
+  end
 end


### PR DESCRIPTION
This pull request will add support to rmvm.rb to remove servers from Satellite & Puppet. I also cleaned up some quoting consistency issues, added arguments from rmvm to mkvm.yaml.sample, and added a blurb to README.md regarding Puppet authentication for rmvm.rb.