### PR TITLE
Remove the cdrom when cloning a VM.

### DIFF
--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end

--- a/lib/vsphere.rb
+++ b/lib/vsphere.rb
@@ -321,6 +321,10 @@ The mapping looks something like:
       clone_spec.config.extraConfig << { :key => 'guestinfo.sdb_path', :value => sdb_path }
     end
 
+    # Remove the cdrom
+    cdrom = source_config.hardware.device.detect { |x| x.deviceInfo.label == "CD/DVD drive 1" }
+    clone_spec.config.deviceChange.push RbVmomi::VIM.VirtualDeviceConfigSpec(:operation=>:remove, :device=> cdrom)
+
     # Extra config for customizing the VM on first boot.
     if not extra.to_s.empty?
       extra.split.each_index { |index|


### PR DESCRIPTION
We only use the cdrom for initial boot on kickstart installs.  There is no need for the device on cloned VMs.

We occasionally attach a rescue image and boot from the cdrom to recover corrupted systems so this would be a manual step to add a cdrom device to the VM.