### PR TITLE
don't die if there is no cdrom

### DIFF
--- a/lib/vsphere.rb
+++ b/lib/vsphere.rb
@@ -342,7 +342,9 @@ The mapping looks something like:
 
     # Remove the cdrom
     cdrom = source_config.hardware.device.detect { |x| x.deviceInfo.label == "CD/DVD drive 1" }
-    clone_spec.config.deviceChange.push RbVmomi::VIM.VirtualDeviceConfigSpec(:operation=>:remove, :device=> cdrom)
+    if not cdrom.nil?
+      clone_spec.config.deviceChange.push RbVmomi::VIM.VirtualDeviceConfigSpec(:operation=>:remove, :device=> cdrom)
+    end
 
     # Extra config for customizing the VM on first boot.
     if not extra.to_s.empty?


### PR DESCRIPTION
This allows cloning of a VM that doesn't have a cdrom attached.