### PR TITLE
Fix another bug with anti-affinity rule management.

### DIFF
--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-  VERSION = '1.2.5'
+  VERSION = '1.2.6'
 end

--- a/lib/vm_drs.rb
+++ b/lib/vm_drs.rb
@@ -1,8 +1,9 @@
 class Vm_drs
 
-  def initialize(dc, cluster, pre, domain, hostnum)
+  def initialize(dc, cluster, search_path, pre, domain, hostnum)
     @dc=dc
     @cluster=cluster
+    @search_path = search_path
     @prefix=pre
     @domain=domain
     @rulename="anti_affinity_#{pre}X"
@@ -36,7 +37,7 @@ class Vm_drs
     delete if exists?
     for i in 1..@hostnum.to_i
       ["#{@prefix}#{i}", "#{@prefix}#{i}.#{@domain}"].each do |pair_name|
-        vm_pair = @dc.find_vm(pair_name) or next
+        vm_pair = @dc.find_vm("#{@search_path}/#{pair_name}") or next
         vm_list.push(vm_pair)
       end
     end

--- a/lib/vsphere.rb
+++ b/lib/vsphere.rb
@@ -287,9 +287,9 @@ The mapping looks something like:
 
   def vc_affinity(dc, cluster, folder, host, domain)
     short = host.split('.')[0]
-    search_path = folder.name.eql?('vm') ? short.chop : "#{folder.name}/#{short.chop}"
+    search_path = folder.name.eql?('vm') ? "" : "#{folder.name}"
     if hostnum = short =~ /([2-9]$)/
-      Vm_drs.new(dc, cluster, search_path, domain, hostnum).create
+      Vm_drs.new(dc, cluster, search_path, short.chop, domain, hostnum).create
     end
   end
 


### PR DESCRIPTION
The previous fix created rules with a URI escaped `/` so the rule names looked like `anti_affinity_foldername%2fhostname`.  The logic for checking for an existing rule silently failed to find the existing rule so we were creating duplicate rules.