### PR TITLE
Add support for multiple disks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2017-11-09
+* MAJOR RELEASE
+* Add support for multiple disks outside of sdb
 2016-07-25
 * MAJOR RELEASE
 * Remove support for build/upload/kickstart from ISO

--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-  VERSION = '2.3'
+  VERSION = '3.0'
 end

--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-  VERSION = '2.2.1'
+  VERSION = '2.3'
 end

--- a/lib/vsphere.rb
+++ b/lib/vsphere.rb
@@ -136,9 +136,13 @@ class Vsphere < Mkvm
 
     debug( 'INFO', "CPU: #{options[:cpu]}" ) if options[:debug]
     debug( 'INFO', "Mem: #{options[:memory]} MiB" ) if options[:debug]
+
+    invalid_mounts = [ '/', '/boot', '/tmp', '/opt', '/var' ]
     if options[:disks]
       options[:disks].each do |disk|
+        abort "#{disk[:path]} is an existing mount" if invalid_mounts.include? disk[:path]
         debug( 'INFO', "disk: #{disk[:size]} KiB with path #{disk[:path]}" )
+        invalid_mounts << disk[:path]
       end
     end
 


### PR DESCRIPTION
This is a breaking change that drops the existing _sdb_ parameter for a generic _disks_ parameter that can be specified multiple times.

 Includes:
* Add validation of mount points to avoid using existing rootvg mounts and avoid duplicates
* Allow passing of _none_ for path to avoid any disk configuration