### PR TITLE
reset boot order to only use HD

### DIFF
--- a/lib/vsphere.rb
+++ b/lib/vsphere.rb
@@ -291,6 +291,9 @@ The mapping looks something like:
       }
     end
 
+    # reset boot order to only boot from HD
+    clone_spec.config.extraConfig << { :key => 'bios.bootDeviceClasses', :value => 'allow:hd' }
+
     return clone_spec
   end
 


### PR DESCRIPTION
The template creation process leaves the VM with a default PXE boot. This change will replace the boot order with just the hard drive, avoiding any future PXE boots.