### PR TITLE
Added Okta ASA support and removed satellite support from rmvm

### DIFF
--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-	VERSION = '3.1.2'
+	VERSION = '3.2.0'
 end

--- a/lib/okta_asa.rb
+++ b/lib/okta_asa.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+
+require "net/https"
+require "uri"
+require "json"
+
+def okta_asa_delete(team_name, key_id, key_secret, hostname)
+
+  okta_url = "https://app.scaleft.com/v1/teams"
+
+  # Get auth token
+  token_uri = URI.parse("#{okta_url}/#{team_name}/service_token")
+
+  header = {"Content-Type": "application/json"}
+
+  http = Net::HTTP.new(token_uri.host, token_uri.port)
+  http.use_ssl = true
+  request = Net::HTTP::Post.new(token_uri.request_uri, header)
+  request.body = {"key_id": key_id,
+                  "key_secret": key_secret}.to_json
+
+  response = http.request(request)
+
+  if response.code != '200'
+    puts "ERROR: Unable to authenticate to Okta. API Response:"
+    puts response.body
+
+    return 1
+  else
+    bearer_token = JSON.parse(response.body)["bearer_token"]
+  end
+
+  # Find the system
+  system_uri = URI.parse("#{okta_url}/#{team_name}/servers?hostname=#{hostname}")
+
+  header = {"Authorization": "Bearer #{bearer_token}"}
+
+  http = Net::HTTP.new(system_uri.host, system_uri.port)
+  http.use_ssl = true
+  request = Net::HTTP::Get.new(system_uri.request_uri, header)
+
+  response = http.request(request)
+
+  if response.code != '200'
+    puts "ERROR: Unable to find server '#{hostname}' from Okta ASA. API Response:"
+    puts response.body
+
+    return 1
+  else
+    host_list = JSON.parse(response.body)["list"]
+
+    if host_list.length < 1
+      puts "WARN: Unable to find server '#{hostname}' from Okta ASA. API returned empty list..."
+      return 0
+    end
+  end
+
+
+  # Delete the system
+  host_list.each do |host|
+    delete_uri = URI.parse("#{okta_url}/#{team_name}/projects/#{host['project_name']}/servers/#{host['id']}")
+
+    header = {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer #{bearer_token}",
+    }
+
+    http = Net::HTTP.new(delete_uri.host, delete_uri.port)
+    http.use_ssl = true
+    request = Net::HTTP::Delete.new(delete_uri.request_uri, header)
+
+    response = http.request(request)
+
+    if response.code.start_with?('2')
+      puts "SUCCESS: '#{hostname}' deleted successfully"
+    else
+      puts "ERROR: Unable to delete server '#{hostname}' from Okta ASA. API Response:"
+      puts response.body
+      
+      return 1
+    end
+  end
+
+  return 0
+end

--- a/lib/okta_asa.rb
+++ b/lib/okta_asa.rb
@@ -42,7 +42,7 @@ def okta_asa_delete(team_name, key_id, key_secret, hostname)
   response = http.request(request)
 
   if response.code != '200'
-    puts "ERROR: Unable to find server '#{hostname}' from Okta ASA. API Response:"
+    puts "ERROR: Okta ASA API returned an error when attempting to find server '#{hostname}'. API resonse:"
     puts response.body
 
     return 1

--- a/lib/okta_asa.rb
+++ b/lib/okta_asa.rb
@@ -57,6 +57,7 @@ def okta_asa_delete(team_name, key_id, key_secret, hostname)
 
 
   # Delete the system
+  delete_errors = 0
   host_list.each do |host|
     delete_uri = URI.parse("#{okta_url}/#{team_name}/projects/#{host['project_name']}/servers/#{host['id']}")
 
@@ -77,9 +78,9 @@ def okta_asa_delete(team_name, key_id, key_secret, hostname)
       puts "ERROR: Unable to delete server '#{hostname}' from Okta ASA. API Response:"
       puts response.body
       
-      return 1
+      delete_errors += 1
     end
   end
 
-  return 0
+  return delete_errors
 end

--- a/mkvm.gemspec
+++ b/mkvm.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "mkvm"
   spec.version       = MKVM::VERSION
   spec.authors       = ["CoverMyMeds"]
-  spec.email         = ["smerrill@covermymeds.com", "dsajner@covermymeds.com", "nchowning@covermymeds.com"]
+  spec.email         = ["smerrill@covermymeds.com", "nchowning@covermymeds.com"]
   spec.summary       = %q{Interact with VMWare to build or remove VMs}
   spec.description   = %q{Wraps rbvmomi to interact with the VMWare API to build or remove VMs.}
   spec.homepage      = "https://github.com/covermymeds/mkvm"

--- a/mkvm.gemspec
+++ b/mkvm.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "mkvm"
   spec.version       = MKVM::VERSION
   spec.authors       = ["CoverMyMeds"]
-  spec.email         = ["smerrill@covermymeds.com", "dsajner@covermymeds.com", "dmorris@covermymeds.com"]
+  spec.email         = ["smerrill@covermymeds.com", "dsajner@covermymeds.com", "nchowning@covermymeds.com"]
   spec.summary       = %q{Interact with VMWare to build or remove VMs}
   spec.description   = %q{Wraps rbvmomi to interact with the VMWare API to build or remove VMs.}
   spec.homepage      = "https://github.com/covermymeds/mkvm"


### PR DESCRIPTION
This PR adds support for Okta ASA ~~and removes support for Red Hat Satellite 6~~. The new code authenticates to Okta, finds the server in question, and then deletes it. If a matching server can't be found, it just throws a "WARNING" message so we will be able to rmvm servers that haven't been moved to Okta yet.