### PR TITLE
Adding datadog downtime when rmvm host

### DIFF
--- a/lib/mkvm/version.rb
+++ b/lib/mkvm/version.rb
@@ -1,3 +1,3 @@
 module MKVM
-	VERSION = '3.2.0'
+	VERSION = '3.3.0'
 end

--- a/mkvm.gemspec
+++ b/mkvm.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "mkvm"
   spec.version       = MKVM::VERSION
   spec.authors       = ["CoverMyMeds"]
-  spec.email         = ["smerrill@covermymeds.com", "nchowning@covermymeds.com"]
+  spec.email         = ["smerrill@covermymeds.com", "nchowning@covermymeds.com", "rwang@covermymeds.com"]
   spec.summary       = %q{Interact with VMWare to build or remove VMs}
   spec.description   = %q{Wraps rbvmomi to interact with the VMWare API to build or remove VMs.}
   spec.homepage      = "https://github.com/covermymeds/mkvm"


### PR DESCRIPTION
Downtiming host for 25 hours in Datadog on rmvm. (Datadog requires 24 hours to have a host completely removed from all metrics). Not all hosts are managed by Datadog at this moment, but we'll downtime them indiscriminately. 

Tested with a non-existing host and it worked just fine
<img width="1521" alt="Screen Shot 2020-10-12 at 3 30 50 PM" src="https://user-images.githubusercontent.com/3320547/95785969-bd98a700-0ca4-11eb-85ef-cd255e9062ff.png">


**Post Merge Steps**
- Build and push an updated mkvm gem to geminabox and install it onto mitmkvm1.cmmint.net
- Update rmvm_wrapper script by adding `--datadog-api-key` & `--datadog-app-key` 
